### PR TITLE
Use google dns if opendns fails

### DIFF
--- a/namesilo_ddns.sh
+++ b/namesilo_ddns.sh
@@ -23,9 +23,47 @@ RESOLVER=resolver$(echo "(($RANDOM%4)+1)"|bc).opendns.com
 ##Get the current public IP using DNS
 CUR_IP="$(dig +short myip.opendns.com @$RESOLVER.opendns.com)"
 
-##Exit if curl failed
-if [ $? -ne 0 ]; then
-   exit 1
+#!/bin/bash
+
+##Domain name:
+DOMAIN="lazed.net"
+
+##Host name. 
+##If you want manage host "myhost.mydomain.tld", then
+HOST="cressida"
+
+##APIKEY obtained from Namesilo:
+APIKEY="ea1ff000e01f0db1832e"
+
+## Do not edit lines below ##
+
+##Saved history pubic IP from last check
+IP_FILE="/var/tmp/IP/MyPubIP"
+
+##Response from Namesilo
+RESPONSE="/tmp/namesilo_response.xml"
+
+##Choose which OpenDNS resolver to use
+RESOLVER=resolver$(echo "(($RANDOM%4)+1)"|bc).opendns.com
+##Get the current public IP 
+CUR_IP="$(dig +short myip.opendns.com @$RESOLVER)"
+ODRC=$?
+
+## Try google dns if opendns failed
+if [ $ODRC -ne 0 ]; then
+   logger -t IP.Check -- IP Lookup at $RESOLVER failed!
+   sleep 5
+##Choose which Google resolver to use
+   RESOLVER=ns$(echo "(($RANDOM%4)+1)"|bc).google.com
+##Get the current public IP 
+   IPQUOTED=$(dig TXT +short o-o.myaddr.l.google.com @$RESOLVER)
+   GORC=$?
+## Exit if google failed
+   if [ $GORC -ne 0 ]; then
+     logger -t IP.Check -- IP Lookup at $RESOLVER failed!
+     exit 1
+   fi
+   CUR_IP=$(echo $IPQUOTED | awk -F'"' '{ print $2}')
 fi
 
 ##Check file for previous IP address
@@ -38,24 +76,24 @@ fi
 ##See if the IP has changed
 if [ "$CUR_IP" != "$KNOWN_IP" ]; then
   echo $CUR_IP > $IP_FILE
-  logger -t IP.Check -- Public IP changed to $CUR_IP
+  logger -t IP.Check -- Public IP changed to $CUR_IP from $RESOLVER
 
   ##Update DNS record in Namesilo:
   curl -s "https://www.namesilo.com/api/dnsListRecords?version=1&type=xml&key=$APIKEY&domain=$DOMAIN" > $DOMAIN.xml 
   RECORD_ID=`xmllint --xpath "//namesilo/reply/resource_record/record_id[../host/text() = '$HOST.$DOMAIN' ]" $DOMAIN.xml | grep -oP '(?<=<record_id>).*?(?=</record_id>)'`
-  curl -s "https://www.namesilo.com/api/dnsUpdateRecord?version=1&type=xml&key=$APIKEY&domain=$DOMAIN&rrid=$RECORD_ID&rrhost=$HOST&rrvalue=$CUR_IP&rrttl=7207" > $RESPONSE
+  curl -s "https://www.namesilo.com/api/dnsUpdateRecord?version=1&type=xml&key=$APIKEY&domain=$DOMAIN&rrid=$RECORD_ID&rrhost=$HOST&rrvalue=$CUR_IP&rrttl=3600" > $RESPONSE
     RESPONSE_CODE=`xmllint --xpath "//namesilo/reply/code/text()"  $RESPONSE`
        case $RESPONSE_CODE in
        300)
          logger -t IP.Check -- Update success. Now $HOST.$DOMAIN IP address is $CUR_IP;;
        280)
-         logger -t IP.Check -- Duplicate record exist. No update necessary;;
+         logger -t IP.Check -- Duplicate record exists. No update necessary;;
        *)
          logger -t IP.Check -- DDNS update failed!;;
      esac
 
 else
-  logger -t IP.Check -- NO IP change
+  logger -t IP.Check -- NO IP change from $RESOLVER
 fi
 
 exit 0


### PR DESCRIPTION
Choose a random google resolver if opendns fails. Add resolver details to logging.
